### PR TITLE
sdk/msg, sdk/agent: make responses compact

### DIFF
--- a/sdk/msg/msg.go
+++ b/sdk/msg/msg.go
@@ -25,14 +25,14 @@ type Message struct {
 
 	Hello *Hello `json:",omitempty"`
 
-	OpenRequest  *state.OpenEnvelope `json:",omitempty"`
-	OpenResponse *state.OpenEnvelope `json:",omitempty"`
+	OpenRequest  *state.OpenEnvelope   `json:",omitempty"`
+	OpenResponse *state.OpenSignatures `json:",omitempty"`
 
-	PaymentRequest  *state.CloseEnvelope `json:",omitempty"`
-	PaymentResponse *state.CloseEnvelope `json:",omitempty"`
+	PaymentRequest  *state.CloseEnvelope   `json:",omitempty"`
+	PaymentResponse *state.CloseSignatures `json:",omitempty"`
 
-	CloseRequest  *state.CloseEnvelope `json:",omitempty"`
-	CloseResponse *state.CloseEnvelope `json:",omitempty"`
+	CloseRequest  *state.CloseEnvelope   `json:",omitempty"`
+	CloseResponse *state.CloseSignatures `json:",omitempty"`
 }
 
 type Hello struct {

--- a/sdk/state/state.go
+++ b/sdk/state/state.go
@@ -208,6 +208,10 @@ func (c *Channel) LatestCloseAgreement() CloseAgreement {
 	return c.latestAuthorizedCloseAgreement
 }
 
+func (c *Channel) LatestUnauthorizedCloseAgreement() (CloseAgreement, bool) {
+	return c.latestUnauthorizedCloseAgreement, !c.latestUnauthorizedCloseAgreement.Envelope.Empty()
+}
+
 func (c *Channel) UpdateLocalEscrowAccountBalance(balance int64) {
 	c.localEscrowAccount.Balance = balance
 }


### PR DESCRIPTION
### What
Make responses compact by reducing them down to only the signatures that need returning to the proposer.

### Why
The message format and agent is implemented such that the confirmer passes back the full close envelope back to the proposer. It was done this way because we planned to possibly support things like [merging channels](https://github.com/stellar/starlight/discussions/330#discussioncomment-1345289) which requires clearly identifying confirmations. Close envelopes were never that big, so we didn't worry about this too much.

However, since we implemented [buffered channel](https://github.com/stellar/starlight/discussions/330#discussioncomment-1345257) the close envelope now contains information about all the buffered payments that are summarized in the memo of the channel's payment. Sending that back in the confirmation is unnecessary and wasteful network traffic.

The only information the confirmer needs to communicate is their signatures.