### PR TITLE
examples/console: fix small amounts

### DIFF
--- a/examples/console/main.go
+++ b/examples/console/main.go
@@ -411,14 +411,14 @@ func prompt(agent *bufferedagent.Agent, stats *stats, submitter agentpkg.Submitt
 		stats.Reset()
 		agent.SetMaxBufferSize(bufferSize)
 		stats.MarkStart()
-		modBy := int64(bufferSize)
-		if modBy > amt {
-			modBy = amt
+		amtRange := int64(bufferSize)
+		if amtRange > amt {
+			amtRange = amt
 		}
 		for i := 0; i < x; i++ {
 			memo := "tx-" + strconv.Itoa(i)
 			for {
-				amt := amt - (int64(i) % modBy)
+				amt := amt - (int64(i) % amtRange)
 				_, err = agent.PaymentWithMemo(amt, memo)
 				if err != nil {
 					continue

--- a/examples/console/main.go
+++ b/examples/console/main.go
@@ -411,10 +411,14 @@ func prompt(agent *bufferedagent.Agent, stats *stats, submitter agentpkg.Submitt
 		stats.Reset()
 		agent.SetMaxBufferSize(bufferSize)
 		stats.MarkStart()
+		modBy := int64(bufferSize)
+		if modBy > amt {
+			modBy = amt
+		}
 		for i := 0; i < x; i++ {
 			memo := "tx-" + strconv.Itoa(i)
 			for {
-				amt := amt - (int64(i) % int64(bufferSize))
+				amt := amt - (int64(i) % modBy)
 				_, err = agent.PaymentWithMemo(amt, memo)
 				if err != nil {
 					continue


### PR DESCRIPTION
### What
Change how amounts are chosen when running a benchmark so that the amount isn't modified to negative.

### Why
I recently changed how amounts are determined so that the amounts are not uniform and don't use a pseudorandom generator. However the change I made caused amounts to go negative. This should fix that.