### PR TITLE
examples/console: update README

### DIFF
--- a/examples/console/README.md
+++ b/examples/console/README.md
@@ -13,18 +13,13 @@ This example is a rough example and is brittle and is still a work in progress.
 Follow the [Getting Started](../../Getting%20Started.md) instructions to run a
 stellar-core and horizon with CAP-21 capabilities.
 
-Run the example providing a G strkey and its S strkey secret key. Generate your
-own keys using stc or the Stellar Laboratory.
+Run the example using the below commands.
 
 ```
 git clone https://github.com/stellar/experimental-payment-channels
 cd examples/console
-go run . -horizon=http://localhost:8000 -account=GCIFBFIALD3GDBNHAA7QHOYMYFEXVZTRY6ICHWDDB5HELJRGVJZ4HB5V -signer=SDD7AE7ZFFXWC4LNAILC5XQCV7J5BHGUJULB2MAHQ4SQS5SCUYG2YFUW
+go run . -horizon=http://localhost:8000
 ```
-
-The application will create the account passed in if needed.
-
-The application will randomly generate and create an escrow account as well.
 
 Type `help` once in to discover commands to use.
 
@@ -36,7 +31,7 @@ tty device.
 
 Run these commands on the first terminal:
 ```
-$ go run . -horizon=http://localhost:8000 -account=GCIFBFIALD3GDBNHAA7QHOYMYFEXVZTRY6ICHWDDB5HELJRGVJZ4HB5V -signer=SDD7AE7ZFFXWC4LNAILC5XQCV7J5BHGUJULB2MAHQ4SQS5SCUYG2YFUW
+$ go run . -horizon=http://localhost:8000
 > listen :6000
 > open
 > deposit 100
@@ -46,9 +41,10 @@ $ go run . -horizon=http://localhost:8000 -account=GCIFBFIALD3GDBNHAA7QHOYMYFEXV
 
 Run these commands in the second terminal:
 ```
-$ go run . -horizon=http://localhost:8000 -account=GBNQ3V2QI47IG5RCSEUF3FDDNYZWWYIKNYBFO3XF2BUV6DZWOEJBM66P -signer=SA5TQFNYZSOSVOIYKKQZ5DLSWS4JEGLR4FACLGQD7DRXDOGWK6N3ABCI
+$ go run . -horizon=http://localhost:8000
 > connect :6000
 > deposit 80
 > pay 2
+> declareclose
 > close
 ```


### PR DESCRIPTION
**WHAT**
updates the example/console README. Things noticed while working on https://github.com/stellar/starlight/pull/403

**WHY**
we removed the need of passing in an account when starting the app but the README still recommends it. the -account flag isn't supported and the -signer flag isn't required now.

also adds the `declareclose` command which is the recommended way to close the channel.