### PR TITLE
sdk/state, sdk/agent: finalize payment

### DIFF
--- a/sdk/agent/agent.go
+++ b/sdk/agent/agent.go
@@ -631,7 +631,8 @@ func (a *Agent) handlePaymentResponse(m msg.Message, send *msg.Encoder) error {
 		return fmt.Errorf("no channel")
 	}
 
-	payment, err := a.channel.FinalizePayment(*m.PaymentResponse)
+	signatures := *m.PaymentResponse
+	payment, err := a.channel.FinalizePayment(signatures)
 	if err != nil {
 		return fmt.Errorf("confirming payment: %w", err)
 	}

--- a/sdk/agent/agent.go
+++ b/sdk/agent/agent.go
@@ -631,10 +631,7 @@ func (a *Agent) handlePaymentResponse(m msg.Message, send *msg.Encoder) error {
 		return fmt.Errorf("no channel")
 	}
 
-	closeAgreement, _ := a.channel.LatestUnauthorizedCloseAgreement()
-	closeEnvelope := closeAgreement.Envelope
-	closeEnvelope.ConfirmerSignatures = *m.PaymentResponse
-	payment, err := a.channel.ConfirmPayment(closeEnvelope)
+	payment, err := a.channel.FinalizePayment(*m.PaymentResponse)
 	if err != nil {
 		return fmt.Errorf("confirming payment: %w", err)
 	}

--- a/sdk/state/doc.go
+++ b/sdk/state/doc.go
@@ -24,7 +24,6 @@ signatures.
         |                  |
      Propose               |
         +----------------->+
-        |                  |
         |               Confirm
         +<-----------------+
     Finalize               |

--- a/sdk/state/doc.go
+++ b/sdk/state/doc.go
@@ -19,19 +19,14 @@ The Open, Payment, and Close operations are broken up into three steps:
 signatures.
 
     +-----------+      +-----------+
-    |           |      |           |
     |   Payer   |      |   Payee   |
-    |           |      |           |
     +-----+-----+      +-----+-----+
-          |                  |
           |                  |
           |Propose           |
           +----------------->+
           |                  |
-          |                  |
           |           Confirm|
   Finalize+<-----------------+
-        | |                  |
         | |                  |
         | |                  |
         +->                  |

--- a/sdk/state/doc.go
+++ b/sdk/state/doc.go
@@ -18,19 +18,17 @@ The Open, Payment, and Close operations are broken up into three steps:
 - Finalize*: Called by the payer to finalize the agreement with the payees
 signatures.
 
-    +-----------+      +-----------+
-    |   Payer   |      |   Payee   |
-    +-----+-----+      +-----+-----+
-          |                  |
-          |Propose           |
-          +----------------->+
-          |                  |
-          |           Confirm|
-  Finalize+<-----------------+
-        | |                  |
-        | |                  |
-        +->                  |
-          |                  |
+  +-----------+      +-----------+
+  |   Payer   |      |   Payee   |
+  +-----+-----+      +-----+-----+
+        |                  |
+     Propose               |
+        +----------------->+
+        |                  |
+        |               Confirm
+        +<-----------------+
+    Finalize               |
+        |                  |
 
 Note that the Open and Close processes do not have a Finalize operation, and the
 Confirm is used in its place at this time. A Finalize operation is likely to be

--- a/sdk/state/doc.go
+++ b/sdk/state/doc.go
@@ -1,0 +1,48 @@
+/*
+Package state contains a state machine, contained in the Channel type, for
+managing a Starlight payment channel.
+
+The Channel type once constructed contains functions for three categories of
+operations:
+- Open: Opening the payment channel.
+- Payment: Making a payment from either participant to the other participant.
+- Close: Coordinating an immediate close the payment channel.
+
+The Channel type also provides functions for ingesting data from the network
+into the state machine. This is necessary to progress the state of the channel
+through states that are based on network activity, such as open and close.
+
+The Open, Payment, and Close operations are broken up into three steps:
+- Propose: Called by the payer to create the agreement.
+- Confirm: Called by the payee to confirm the agreement.
+- Finalize*: Called by the payer to finalize the agreement with the payees
+signatures.
+
+    +-----------+      +-----------+
+    |           |      |           |
+    |   Payer   |      |   Payee   |
+    |           |      |           |
+    +-----+-----+      +-----+-----+
+          |                  |
+          |                  |
+          |Propose           |
+          +----------------->+
+          |                  |
+          |                  |
+          |           Confirm|
+  Finalize+<-----------------+
+        | |                  |
+        | |                  |
+        | |                  |
+        +->                  |
+          |                  |
+
+Note that the Open and Close processes do not have a Finalize operation, and the
+Confirm is used in its place at this time. A Finalize operation is likely to be
+added in the future.
+
+None of the primitives in this package are threadsafe and synchronization
+must be provided by the caller if the package is used in a concurrent
+context.
+*/
+package state

--- a/sdk/state/doc.go
+++ b/sdk/state/doc.go
@@ -26,10 +26,10 @@ signatures.
         +----------------->+
         |               Confirm
         +<-----------------+
-    Finalize               |
+    Finalize*              |
         |                  |
 
-Note that the Open and Close processes do not have a Finalize operation, and the
+* Note that the Open and Close processes do not have a Finalize operation, and the
 Confirm is used in its place at this time. A Finalize operation is likely to be
 added in the future.
 

--- a/sdk/state/payment.go
+++ b/sdk/state/payment.go
@@ -152,10 +152,17 @@ func (ca CloseAgreement) SignedTransactions() CloseTransactions {
 	}
 }
 
+// ProposePayment proposes a new payment from the local, the caller of the
+// function, to the remote. ProposePayment is the first step in the process that
+// the paricipants use to make a payment from a payer to a payee.
 func (c *Channel) ProposePayment(amount int64) (CloseAgreement, error) {
 	return c.ProposePaymentWithMemo(amount, nil)
 }
 
+// ProposePaymentWithMemo proposes a new payment that has a byte memo attached
+// to it. The memo can be used to store an identifier or any amount of
+// information about the payment. See the ProposePayment function for more
+// information.
 func (c *Channel) ProposePaymentWithMemo(amount int64, memo []byte) (CloseAgreement, error) {
 	if amount < 0 {
 		return CloseAgreement{}, fmt.Errorf("payment amount must not be less than 0")
@@ -223,6 +230,8 @@ func (c *Channel) ProposePaymentWithMemo(amount int64, memo []byte) (CloseAgreem
 	return c.latestUnauthorizedCloseAgreement, nil
 }
 
+// ErrUnderfunded indicates that the account has insufficient funds to make a
+// specific payment amount.
 var ErrUnderfunded = fmt.Errorf("account is underfunded to make payment")
 
 // validatePayment validates the close agreement given to the ConfirmPayment method. Note that
@@ -278,8 +287,7 @@ func (c *Channel) validatePayment(ce CloseEnvelope) (err error) {
 }
 
 // ConfirmPayment confirms an agreement. The destination of a payment calls this
-// once to sign and store the agreement. The source of a payment calls this once
-// with a copy of the agreement signed by the destination to store the destination's signatures.
+// once to sign and store the agreement.
 func (c *Channel) ConfirmPayment(ce CloseEnvelope) (closeAgreement CloseAgreement, err error) {
 	err = c.validatePayment(ce)
 	if err != nil {

--- a/sdk/state/payment_test.go
+++ b/sdk/state/payment_test.go
@@ -1369,6 +1369,112 @@ func TestChannel_ConfirmPayment_signatureChecks(t *testing.T) {
 	require.NoError(t, err)
 }
 
+func TestChannel_FinalizePayment_signatureChecks(t *testing.T) {
+	localSigner := keypair.MustRandom()
+	remoteSigner := keypair.MustRandom()
+	localEscrowAccount := keypair.MustRandom().FromAddress()
+	remoteEscrowAccount := keypair.MustRandom().FromAddress()
+
+	// Given a channel with observation periods set to 1.
+	responderChannel := NewChannel(Config{
+		NetworkPassphrase:   network.TestNetworkPassphrase,
+		Initiator:           false,
+		LocalSigner:         localSigner,
+		RemoteSigner:        remoteSigner.FromAddress(),
+		LocalEscrowAccount:  localEscrowAccount,
+		RemoteEscrowAccount: remoteEscrowAccount,
+		MaxOpenExpiry:       2 * time.Hour,
+	})
+	initiatorChannel := NewChannel(Config{
+		NetworkPassphrase:   network.TestNetworkPassphrase,
+		Initiator:           true,
+		LocalSigner:         remoteSigner,
+		RemoteSigner:        localSigner.FromAddress(),
+		LocalEscrowAccount:  remoteEscrowAccount,
+		RemoteEscrowAccount: localEscrowAccount,
+		MaxOpenExpiry:       2 * time.Hour,
+	})
+
+	// Put channel into the Open state.
+	{
+		m, err := initiatorChannel.ProposeOpen(OpenParams{
+			ObservationPeriodLedgerGap: 10,
+			Asset:                      NativeAsset,
+			ExpiresAt:                  time.Now().Add(5 * time.Minute),
+			StartingSequence:           101,
+		})
+		require.NoError(t, err)
+		m, err = responderChannel.ConfirmOpen(m.Envelope)
+		require.NoError(t, err)
+		_, err = initiatorChannel.ConfirmOpen(m.Envelope)
+		require.NoError(t, err)
+
+		ftx, err := initiatorChannel.OpenTx()
+		require.NoError(t, err)
+		ftxXDR, err := ftx.Base64()
+		require.NoError(t, err)
+
+		successResultXDR, err := txbuildtest.BuildResultXDR(true)
+		require.NoError(t, err)
+		resultMetaXDR, err := txbuildtest.BuildOpenResultMetaXDR(txbuildtest.OpenResultMetaParams{
+			InitiatorSigner: remoteSigner.Address(),
+			ResponderSigner: localSigner.Address(),
+			InitiatorEscrow: remoteEscrowAccount.Address(),
+			ResponderEscrow: localEscrowAccount.Address(),
+			StartSequence:   101,
+			Asset:           txnbuild.NativeAsset{},
+		})
+		require.NoError(t, err)
+
+		err = responderChannel.IngestTx(1, ftxXDR, successResultXDR, resultMetaXDR)
+		require.NoError(t, err)
+		cs, err := responderChannel.State()
+		require.NoError(t, err)
+		assert.Equal(t, StateOpen, cs)
+
+		err = initiatorChannel.IngestTx(1, ftxXDR, successResultXDR, resultMetaXDR)
+		require.NoError(t, err)
+		cs, err = initiatorChannel.State()
+		require.NoError(t, err)
+		assert.Equal(t, StateOpen, cs)
+	}
+	initiatorChannel.UpdateLocalEscrowAccountBalance(200)
+	responderChannel.UpdateRemoteEscrowAccountBalance(200)
+
+	ca, err := initiatorChannel.ProposePayment(100)
+	require.NoError(t, err)
+	ca, err = responderChannel.ConfirmPayment(ca.Envelope)
+	require.NoError(t, err)
+
+	// Pretend that confirmer did not sign any tx.
+	_, err = initiatorChannel.FinalizePayment(CloseSignatures{})
+	require.EqualError(t, err, "invalid signature: signature verification failed")
+
+	// Pretend that the confirmer did not sign a tx.
+	_, err = initiatorChannel.FinalizePayment(CloseSignatures{
+		Declaration: ca.Envelope.ConfirmerSignatures.Declaration,
+	})
+	require.EqualError(t, err, "invalid signature: signature verification failed")
+	_, err = initiatorChannel.FinalizePayment(CloseSignatures{
+		Close: ca.Envelope.ConfirmerSignatures.Close,
+	})
+	require.EqualError(t, err, "invalid signature: signature verification failed")
+
+	// Pretend that the confirmer signed the txs invalidly.
+	_, err = initiatorChannel.FinalizePayment(CloseSignatures{
+		Close: ca.Envelope.ConfirmerSignatures.Declaration,
+	})
+	require.EqualError(t, err, "invalid signature: signature verification failed")
+	_, err = initiatorChannel.FinalizePayment(CloseSignatures{
+		Declaration: ca.Envelope.ConfirmerSignatures.Close,
+	})
+	require.EqualError(t, err, "invalid signature: signature verification failed")
+
+	// Valid proposer and confirmer signatures accepted by proposer.
+	_, err = initiatorChannel.FinalizePayment(ca.Envelope.ConfirmerSignatures)
+	require.NoError(t, err)
+}
+
 func TestLastConfirmedPayment(t *testing.T) {
 	localSigner := keypair.MustRandom()
 	remoteSigner := keypair.MustRandom()

--- a/sdk/state/payment_test.go
+++ b/sdk/state/payment_test.go
@@ -1369,6 +1369,91 @@ func TestChannel_ConfirmPayment_signatureChecks(t *testing.T) {
 	require.NoError(t, err)
 }
 
+func TestChannel_FinalizePayment_noUnauthorizedAgreement(t *testing.T) {
+	localSigner := keypair.MustRandom()
+	remoteSigner := keypair.MustRandom()
+	localEscrowAccount := keypair.MustRandom().FromAddress()
+	remoteEscrowAccount := keypair.MustRandom().FromAddress()
+
+	// Given a channel with observation periods set to 1.
+	responderChannel := NewChannel(Config{
+		NetworkPassphrase:   network.TestNetworkPassphrase,
+		Initiator:           false,
+		LocalSigner:         localSigner,
+		RemoteSigner:        remoteSigner.FromAddress(),
+		LocalEscrowAccount:  localEscrowAccount,
+		RemoteEscrowAccount: remoteEscrowAccount,
+		MaxOpenExpiry:       2 * time.Hour,
+	})
+	initiatorChannel := NewChannel(Config{
+		NetworkPassphrase:   network.TestNetworkPassphrase,
+		Initiator:           true,
+		LocalSigner:         remoteSigner,
+		RemoteSigner:        localSigner.FromAddress(),
+		LocalEscrowAccount:  remoteEscrowAccount,
+		RemoteEscrowAccount: localEscrowAccount,
+		MaxOpenExpiry:       2 * time.Hour,
+	})
+
+	// Put channel into the Open state.
+	{
+		m, err := initiatorChannel.ProposeOpen(OpenParams{
+			ObservationPeriodLedgerGap: 10,
+			Asset:                      NativeAsset,
+			ExpiresAt:                  time.Now().Add(5 * time.Minute),
+			StartingSequence:           101,
+		})
+		require.NoError(t, err)
+		m, err = responderChannel.ConfirmOpen(m.Envelope)
+		require.NoError(t, err)
+		_, err = initiatorChannel.ConfirmOpen(m.Envelope)
+		require.NoError(t, err)
+
+		ftx, err := initiatorChannel.OpenTx()
+		require.NoError(t, err)
+		ftxXDR, err := ftx.Base64()
+		require.NoError(t, err)
+
+		successResultXDR, err := txbuildtest.BuildResultXDR(true)
+		require.NoError(t, err)
+		resultMetaXDR, err := txbuildtest.BuildOpenResultMetaXDR(txbuildtest.OpenResultMetaParams{
+			InitiatorSigner: remoteSigner.Address(),
+			ResponderSigner: localSigner.Address(),
+			InitiatorEscrow: remoteEscrowAccount.Address(),
+			ResponderEscrow: localEscrowAccount.Address(),
+			StartSequence:   101,
+			Asset:           txnbuild.NativeAsset{},
+		})
+		require.NoError(t, err)
+
+		err = responderChannel.IngestTx(1, ftxXDR, successResultXDR, resultMetaXDR)
+		require.NoError(t, err)
+		cs, err := responderChannel.State()
+		require.NoError(t, err)
+		assert.Equal(t, StateOpen, cs)
+
+		err = initiatorChannel.IngestTx(1, ftxXDR, successResultXDR, resultMetaXDR)
+		require.NoError(t, err)
+		cs, err = initiatorChannel.State()
+		require.NoError(t, err)
+		assert.Equal(t, StateOpen, cs)
+	}
+	initiatorChannel.UpdateLocalEscrowAccountBalance(200)
+	responderChannel.UpdateRemoteEscrowAccountBalance(200)
+
+	ca, err := initiatorChannel.ProposePayment(100)
+	require.NoError(t, err)
+	ca, err = responderChannel.ConfirmPayment(ca.Envelope)
+	require.NoError(t, err)
+	_, err = initiatorChannel.FinalizePayment(ca.Envelope.ConfirmerSignatures)
+	require.NoError(t, err)
+
+	// Try finalizing a payment when there is no unauthorized payment because
+	// all payments have been authorized. Should error.
+	_, err = initiatorChannel.FinalizePayment(ca.Envelope.ConfirmerSignatures)
+	require.EqualError(t, err, "no unauthorized close agreement to finalize")
+}
+
 func TestChannel_FinalizePayment_signatureChecks(t *testing.T) {
 	localSigner := keypair.MustRandom()
 	remoteSigner := keypair.MustRandom()


### PR DESCRIPTION
### What
Add a finalize payment function that a payment proposer can use to finalize a payment when the confirmer sends back their signatures.

### Why
Today this functionality is provided by the `ConfirmPayment` function that is used by both the proposer and the confirmer. Because it is used by both it accepts a full close agreement envelope and does a lot of validation of the contents. The proposer gets back the signatures from the confirmer and doesn't actually need to verify the agreement. They just need to attach the signatures and see if they're valid. That's what the finalize payment function does.

This change has no material performance improvement. I attempted the change to see if it improved performance and it did not in a meaningful way. Reflecting on it though, this does feel like it naturally makes sense and it simplifies some logic we have in the agent. When the agent is confirming the payment for a proposer it no longer needs to get the close agreement and attach the signatures.