### PR TITLE
examples/console: fix deposits to other

### DIFF
--- a/examples/console/main.go
+++ b/examples/console/main.go
@@ -378,7 +378,7 @@ func runShell(agent *bufferedagent.Agent, stats *stats, submitter agentpkg.Submi
 		Func: func(c *ishell.Context) {
 			depositAmountStr := c.Args[0]
 			destination := escrowAccount
-			if len(c.Args) >= 3 && c.Args[1] == "other" {
+			if len(c.Args) >= 2 && c.Args[1] == "other" {
 				destination = otherEscrowAccount
 			}
 			account, err := horizonClient.AccountDetail(horizonclient.AccountRequest{AccountID: account.Address()})


### PR DESCRIPTION
### What
When 'other' is included in the deposit command as the second parameter, have the deposit go to the other participant.

### Why
This is how the deposit used to work, but a bug was introduced recently which prevented us from following the code path where the deposit was directed to the other participant.