### PR TITLE
all: update to use latest stellar/go branch

### DIFF
--- a/examples/benchmark/go.mod
+++ b/examples/benchmark/go.mod
@@ -6,7 +6,7 @@ replace github.com/stellar/experimental-payment-channels/sdk => ../../sdk
 
 require (
 	github.com/stellar/experimental-payment-channels/sdk v0.0.0-00010101000000-000000000000
-	github.com/stellar/go v0.0.0-20211101224627-ea4e6e6e5b27
+	github.com/stellar/go v0.0.0-20211104231909-68ccd74d8906
 	gopkg.in/yaml.v2 v2.3.0 // indirect
 )
 
@@ -21,7 +21,7 @@ require (
 	github.com/pmezard/go-difflib v1.0.0 // indirect
 	github.com/segmentio/go-loggly v0.5.1-0.20171222203950-eb91657e62b2 // indirect
 	github.com/sirupsen/logrus v1.4.1 // indirect
-	github.com/stellar/go-xdr v0.0.0-20201028102745-f80a23dac78a // indirect
+	github.com/stellar/go-xdr v0.0.0-20211103144802-8017fc4bdfee // indirect
 	github.com/stretchr/objx v0.3.0 // indirect
 	github.com/stretchr/testify v1.7.0 // indirect
 	golang.org/x/sync v0.0.0-20210220032951-036812b2e83c // indirect

--- a/examples/benchmark/go.sum
+++ b/examples/benchmark/go.sum
@@ -258,10 +258,10 @@ github.com/spf13/cobra v0.0.0-20160830174925-9c28e4bbd74e/go.mod h1:1l0Ry5zgKvJa
 github.com/spf13/jwalterweatherman v0.0.0-20141219030609-3d60171a6431/go.mod h1:cQK4TGJAtQXfYWX+Ddv3mKDzgVb68N+wFjFa4jdeBTo=
 github.com/spf13/pflag v0.0.0-20161005214240-4bd69631f475/go.mod h1:DYY7MBk1bdzusC3SYhjObp+wFpr4gzcvqqNjLnInEg4=
 github.com/spf13/viper v0.0.0-20150621231900-db7ff930a189/go.mod h1:A8kyI5cUJhb8N+3pkfONlcEcZbueH6nhAm0Fq7SrnBM=
-github.com/stellar/go v0.0.0-20211101224627-ea4e6e6e5b27 h1:UW8+ifin0aIlddfSknN/bDieZY3Wbzt1qN4+aZ13Enc=
-github.com/stellar/go v0.0.0-20211101224627-ea4e6e6e5b27/go.mod h1:H+AG8jyBM3bHICvpYayk0YZyRWax36FYFJJSrrO4cI4=
-github.com/stellar/go-xdr v0.0.0-20201028102745-f80a23dac78a h1:GnM0ArRp7EDbaTiFhSp/CLgyk2cacXxdUklqJmdJs1Q=
-github.com/stellar/go-xdr v0.0.0-20201028102745-f80a23dac78a/go.mod h1:yoxyU/M8nl9LKeWIoBrbDPQ7Cy+4jxRcWcOayZ4BMps=
+github.com/stellar/go v0.0.0-20211104231909-68ccd74d8906 h1:qs6mqK1CKEP80I29z4Qdvp0wN5uTZ+ODlK01LQKyDMc=
+github.com/stellar/go v0.0.0-20211104231909-68ccd74d8906/go.mod h1:Pn4pa7blbDIoCDU6G8qxKpwCK4KF/GVS13Sc1qAROrE=
+github.com/stellar/go-xdr v0.0.0-20211103144802-8017fc4bdfee h1:fbVs0xmXpBvVS4GBeiRmAE3Le70ofAqFMch1GTiq/e8=
+github.com/stellar/go-xdr v0.0.0-20211103144802-8017fc4bdfee/go.mod h1:yoxyU/M8nl9LKeWIoBrbDPQ7Cy+4jxRcWcOayZ4BMps=
 github.com/stellar/throttled v2.2.3-0.20190823235211-89d75816f59d+incompatible/go.mod h1:7CJ23pXirXBJq45DqvO6clzTEGM/l1SfKrgrzLry8b4=
 github.com/stretchr/objx v0.1.0/go.mod h1:HFkY916IF+rwdDfMAkV7OtwuqBVzrE8GR6GFx+wExME=
 github.com/stretchr/objx v0.1.1/go.mod h1:HFkY916IF+rwdDfMAkV7OtwuqBVzrE8GR6GFx+wExME=

--- a/examples/bufferedbenchmark/go.mod
+++ b/examples/bufferedbenchmark/go.mod
@@ -6,7 +6,7 @@ replace github.com/stellar/experimental-payment-channels/sdk => ../../sdk
 
 require (
 	github.com/stellar/experimental-payment-channels/sdk v0.0.0-00010101000000-000000000000
-	github.com/stellar/go v0.0.0-20211101224627-ea4e6e6e5b27
+	github.com/stellar/go v0.0.0-20211104231909-68ccd74d8906
 	gopkg.in/yaml.v2 v2.3.0 // indirect
 )
 
@@ -27,7 +27,7 @@ require (
 	github.com/rs/xhandler v0.0.0-20160618193221-ed27b6fd6521 // indirect
 	github.com/segmentio/go-loggly v0.5.1-0.20171222203950-eb91657e62b2 // indirect
 	github.com/sirupsen/logrus v1.4.1 // indirect
-	github.com/stellar/go-xdr v0.0.0-20201028102745-f80a23dac78a // indirect
+	github.com/stellar/go-xdr v0.0.0-20211103144802-8017fc4bdfee // indirect
 	github.com/stretchr/objx v0.3.0 // indirect
 	github.com/stretchr/testify v1.7.0 // indirect
 	golang.org/x/net v0.0.0-20210614182718-04defd469f4e // indirect

--- a/examples/bufferedbenchmark/go.sum
+++ b/examples/bufferedbenchmark/go.sum
@@ -261,10 +261,10 @@ github.com/spf13/cobra v0.0.0-20160830174925-9c28e4bbd74e/go.mod h1:1l0Ry5zgKvJa
 github.com/spf13/jwalterweatherman v0.0.0-20141219030609-3d60171a6431/go.mod h1:cQK4TGJAtQXfYWX+Ddv3mKDzgVb68N+wFjFa4jdeBTo=
 github.com/spf13/pflag v0.0.0-20161005214240-4bd69631f475/go.mod h1:DYY7MBk1bdzusC3SYhjObp+wFpr4gzcvqqNjLnInEg4=
 github.com/spf13/viper v0.0.0-20150621231900-db7ff930a189/go.mod h1:A8kyI5cUJhb8N+3pkfONlcEcZbueH6nhAm0Fq7SrnBM=
-github.com/stellar/go v0.0.0-20211101224627-ea4e6e6e5b27 h1:UW8+ifin0aIlddfSknN/bDieZY3Wbzt1qN4+aZ13Enc=
-github.com/stellar/go v0.0.0-20211101224627-ea4e6e6e5b27/go.mod h1:H+AG8jyBM3bHICvpYayk0YZyRWax36FYFJJSrrO4cI4=
-github.com/stellar/go-xdr v0.0.0-20201028102745-f80a23dac78a h1:GnM0ArRp7EDbaTiFhSp/CLgyk2cacXxdUklqJmdJs1Q=
-github.com/stellar/go-xdr v0.0.0-20201028102745-f80a23dac78a/go.mod h1:yoxyU/M8nl9LKeWIoBrbDPQ7Cy+4jxRcWcOayZ4BMps=
+github.com/stellar/go v0.0.0-20211104231909-68ccd74d8906 h1:qs6mqK1CKEP80I29z4Qdvp0wN5uTZ+ODlK01LQKyDMc=
+github.com/stellar/go v0.0.0-20211104231909-68ccd74d8906/go.mod h1:Pn4pa7blbDIoCDU6G8qxKpwCK4KF/GVS13Sc1qAROrE=
+github.com/stellar/go-xdr v0.0.0-20211103144802-8017fc4bdfee h1:fbVs0xmXpBvVS4GBeiRmAE3Le70ofAqFMch1GTiq/e8=
+github.com/stellar/go-xdr v0.0.0-20211103144802-8017fc4bdfee/go.mod h1:yoxyU/M8nl9LKeWIoBrbDPQ7Cy+4jxRcWcOayZ4BMps=
 github.com/stellar/throttled v2.2.3-0.20190823235211-89d75816f59d+incompatible/go.mod h1:7CJ23pXirXBJq45DqvO6clzTEGM/l1SfKrgrzLry8b4=
 github.com/stretchr/objx v0.1.0/go.mod h1:HFkY916IF+rwdDfMAkV7OtwuqBVzrE8GR6GFx+wExME=
 github.com/stretchr/objx v0.1.1/go.mod h1:HFkY916IF+rwdDfMAkV7OtwuqBVzrE8GR6GFx+wExME=

--- a/examples/console/go.mod
+++ b/examples/console/go.mod
@@ -33,7 +33,7 @@ require (
 	github.com/rs/xhandler v0.0.0-20160618193221-ed27b6fd6521 // indirect
 	github.com/segmentio/go-loggly v0.5.1-0.20171222203950-eb91657e62b2 // indirect
 	github.com/sirupsen/logrus v1.4.1 // indirect
-	github.com/stellar/go-xdr v0.0.0-20201028102745-f80a23dac78a // indirect
+	github.com/stellar/go-xdr v0.0.0-20211103144802-8017fc4bdfee // indirect
 	github.com/stretchr/objx v0.3.0 // indirect
 	github.com/stretchr/testify v1.7.0 // indirect
 	golang.org/x/net v0.0.0-20210614182718-04defd469f4e // indirect
@@ -41,3 +41,5 @@ require (
 	golang.org/x/sys v0.0.0-20210630005230-0f9fa26af87c // indirect
 	gopkg.in/yaml.v3 v3.0.0-20210107192922-496545a6307b // indirect
 )
+
+replace github.com/stellar/go => github.com/stellar/go v0.0.0-20211104231909-68ccd74d8906

--- a/examples/console/go.mod
+++ b/examples/console/go.mod
@@ -8,7 +8,7 @@ require (
 	github.com/abiosoft/ishell v2.0.0+incompatible
 	github.com/rs/cors v0.0.0-20160617231935-a62a804a8a00
 	github.com/stellar/experimental-payment-channels/sdk v0.0.0-00010101000000-000000000000
-	github.com/stellar/go v0.0.0-20211101224627-ea4e6e6e5b27
+	github.com/stellar/go v0.0.0-20211104231909-68ccd74d8906
 	gopkg.in/yaml.v2 v2.3.0 // indirect
 )
 
@@ -41,5 +41,3 @@ require (
 	golang.org/x/sys v0.0.0-20210630005230-0f9fa26af87c // indirect
 	gopkg.in/yaml.v3 v3.0.0-20210107192922-496545a6307b // indirect
 )
-
-replace github.com/stellar/go => github.com/stellar/go v0.0.0-20211104231909-68ccd74d8906

--- a/examples/console/go.sum
+++ b/examples/console/go.sum
@@ -276,10 +276,11 @@ github.com/spf13/cobra v0.0.0-20160830174925-9c28e4bbd74e/go.mod h1:1l0Ry5zgKvJa
 github.com/spf13/jwalterweatherman v0.0.0-20141219030609-3d60171a6431/go.mod h1:cQK4TGJAtQXfYWX+Ddv3mKDzgVb68N+wFjFa4jdeBTo=
 github.com/spf13/pflag v0.0.0-20161005214240-4bd69631f475/go.mod h1:DYY7MBk1bdzusC3SYhjObp+wFpr4gzcvqqNjLnInEg4=
 github.com/spf13/viper v0.0.0-20150621231900-db7ff930a189/go.mod h1:A8kyI5cUJhb8N+3pkfONlcEcZbueH6nhAm0Fq7SrnBM=
-github.com/stellar/go v0.0.0-20211101224627-ea4e6e6e5b27 h1:UW8+ifin0aIlddfSknN/bDieZY3Wbzt1qN4+aZ13Enc=
-github.com/stellar/go v0.0.0-20211101224627-ea4e6e6e5b27/go.mod h1:H+AG8jyBM3bHICvpYayk0YZyRWax36FYFJJSrrO4cI4=
-github.com/stellar/go-xdr v0.0.0-20201028102745-f80a23dac78a h1:GnM0ArRp7EDbaTiFhSp/CLgyk2cacXxdUklqJmdJs1Q=
+github.com/stellar/go v0.0.0-20211104231909-68ccd74d8906 h1:qs6mqK1CKEP80I29z4Qdvp0wN5uTZ+ODlK01LQKyDMc=
+github.com/stellar/go v0.0.0-20211104231909-68ccd74d8906/go.mod h1:Pn4pa7blbDIoCDU6G8qxKpwCK4KF/GVS13Sc1qAROrE=
 github.com/stellar/go-xdr v0.0.0-20201028102745-f80a23dac78a/go.mod h1:yoxyU/M8nl9LKeWIoBrbDPQ7Cy+4jxRcWcOayZ4BMps=
+github.com/stellar/go-xdr v0.0.0-20211103144802-8017fc4bdfee h1:fbVs0xmXpBvVS4GBeiRmAE3Le70ofAqFMch1GTiq/e8=
+github.com/stellar/go-xdr v0.0.0-20211103144802-8017fc4bdfee/go.mod h1:yoxyU/M8nl9LKeWIoBrbDPQ7Cy+4jxRcWcOayZ4BMps=
 github.com/stellar/throttled v2.2.3-0.20190823235211-89d75816f59d+incompatible/go.mod h1:7CJ23pXirXBJq45DqvO6clzTEGM/l1SfKrgrzLry8b4=
 github.com/stretchr/objx v0.1.0/go.mod h1:HFkY916IF+rwdDfMAkV7OtwuqBVzrE8GR6GFx+wExME=
 github.com/stretchr/objx v0.1.1/go.mod h1:HFkY916IF+rwdDfMAkV7OtwuqBVzrE8GR6GFx+wExME=

--- a/examples/console/go.sum
+++ b/examples/console/go.sum
@@ -278,7 +278,6 @@ github.com/spf13/pflag v0.0.0-20161005214240-4bd69631f475/go.mod h1:DYY7MBk1bdzu
 github.com/spf13/viper v0.0.0-20150621231900-db7ff930a189/go.mod h1:A8kyI5cUJhb8N+3pkfONlcEcZbueH6nhAm0Fq7SrnBM=
 github.com/stellar/go v0.0.0-20211104231909-68ccd74d8906 h1:qs6mqK1CKEP80I29z4Qdvp0wN5uTZ+ODlK01LQKyDMc=
 github.com/stellar/go v0.0.0-20211104231909-68ccd74d8906/go.mod h1:Pn4pa7blbDIoCDU6G8qxKpwCK4KF/GVS13Sc1qAROrE=
-github.com/stellar/go-xdr v0.0.0-20201028102745-f80a23dac78a/go.mod h1:yoxyU/M8nl9LKeWIoBrbDPQ7Cy+4jxRcWcOayZ4BMps=
 github.com/stellar/go-xdr v0.0.0-20211103144802-8017fc4bdfee h1:fbVs0xmXpBvVS4GBeiRmAE3Le70ofAqFMch1GTiq/e8=
 github.com/stellar/go-xdr v0.0.0-20211103144802-8017fc4bdfee/go.mod h1:yoxyU/M8nl9LKeWIoBrbDPQ7Cy+4jxRcWcOayZ4BMps=
 github.com/stellar/throttled v2.2.3-0.20190823235211-89d75816f59d+incompatible/go.mod h1:7CJ23pXirXBJq45DqvO6clzTEGM/l1SfKrgrzLry8b4=

--- a/sdk/go.mod
+++ b/sdk/go.mod
@@ -7,7 +7,7 @@ require (
 	github.com/google/uuid v1.2.0
 	github.com/klauspost/compress v0.0.0-20161106143436-e3b7981a12dd
 	github.com/rs/cors v0.0.0-20160617231935-a62a804a8a00
-	github.com/stellar/go v0.0.0-20211101224627-ea4e6e6e5b27
+	github.com/stellar/go v0.0.0-20211104231909-68ccd74d8906
 	github.com/stretchr/objx v0.3.0 // indirect
 	github.com/stretchr/testify v1.7.0
 	golang.org/x/sync v0.0.0-20210220032951-036812b2e83c
@@ -28,7 +28,7 @@ require (
 	github.com/rs/xhandler v0.0.0-20160618193221-ed27b6fd6521 // indirect
 	github.com/segmentio/go-loggly v0.5.1-0.20171222203950-eb91657e62b2 // indirect
 	github.com/sirupsen/logrus v1.4.1 // indirect
-	github.com/stellar/go-xdr v0.0.0-20201028102745-f80a23dac78a // indirect
+	github.com/stellar/go-xdr v0.0.0-20211103144802-8017fc4bdfee // indirect
 	golang.org/x/net v0.0.0-20210614182718-04defd469f4e // indirect
 	golang.org/x/sys v0.0.0-20210630005230-0f9fa26af87c // indirect
 )

--- a/sdk/go.sum
+++ b/sdk/go.sum
@@ -261,10 +261,10 @@ github.com/spf13/cobra v0.0.0-20160830174925-9c28e4bbd74e/go.mod h1:1l0Ry5zgKvJa
 github.com/spf13/jwalterweatherman v0.0.0-20141219030609-3d60171a6431/go.mod h1:cQK4TGJAtQXfYWX+Ddv3mKDzgVb68N+wFjFa4jdeBTo=
 github.com/spf13/pflag v0.0.0-20161005214240-4bd69631f475/go.mod h1:DYY7MBk1bdzusC3SYhjObp+wFpr4gzcvqqNjLnInEg4=
 github.com/spf13/viper v0.0.0-20150621231900-db7ff930a189/go.mod h1:A8kyI5cUJhb8N+3pkfONlcEcZbueH6nhAm0Fq7SrnBM=
-github.com/stellar/go v0.0.0-20211101224627-ea4e6e6e5b27 h1:UW8+ifin0aIlddfSknN/bDieZY3Wbzt1qN4+aZ13Enc=
-github.com/stellar/go v0.0.0-20211101224627-ea4e6e6e5b27/go.mod h1:H+AG8jyBM3bHICvpYayk0YZyRWax36FYFJJSrrO4cI4=
-github.com/stellar/go-xdr v0.0.0-20201028102745-f80a23dac78a h1:GnM0ArRp7EDbaTiFhSp/CLgyk2cacXxdUklqJmdJs1Q=
-github.com/stellar/go-xdr v0.0.0-20201028102745-f80a23dac78a/go.mod h1:yoxyU/M8nl9LKeWIoBrbDPQ7Cy+4jxRcWcOayZ4BMps=
+github.com/stellar/go v0.0.0-20211104231909-68ccd74d8906 h1:qs6mqK1CKEP80I29z4Qdvp0wN5uTZ+ODlK01LQKyDMc=
+github.com/stellar/go v0.0.0-20211104231909-68ccd74d8906/go.mod h1:Pn4pa7blbDIoCDU6G8qxKpwCK4KF/GVS13Sc1qAROrE=
+github.com/stellar/go-xdr v0.0.0-20211103144802-8017fc4bdfee h1:fbVs0xmXpBvVS4GBeiRmAE3Le70ofAqFMch1GTiq/e8=
+github.com/stellar/go-xdr v0.0.0-20211103144802-8017fc4bdfee/go.mod h1:yoxyU/M8nl9LKeWIoBrbDPQ7Cy+4jxRcWcOayZ4BMps=
 github.com/stellar/throttled v2.2.3-0.20190823235211-89d75816f59d+incompatible/go.mod h1:7CJ23pXirXBJq45DqvO6clzTEGM/l1SfKrgrzLry8b4=
 github.com/stretchr/objx v0.1.0/go.mod h1:HFkY916IF+rwdDfMAkV7OtwuqBVzrE8GR6GFx+wExME=
 github.com/stretchr/objx v0.1.1/go.mod h1:HFkY916IF+rwdDfMAkV7OtwuqBVzrE8GR6GFx+wExME=


### PR DESCRIPTION
### What
Update the stellar/go dependency to use the latest commit of the cap21and40 branch.

### Why
The latest commit contains updates to the version of go-xdr that is used that provides more efficient transaction encoding and decoding. It also contains updated XDR.