### PR TITLE
doc: remove enable accelerate time

### DIFF
--- a/Getting Started.md
+++ b/Getting Started.md
@@ -14,7 +14,7 @@ docker build -t stellar/quickstart:cap21and40 https://github.com/stellar/docker-
 ```
 
 ```
-docker run --rm -it -p 8000:8000 --name stellar stellar/quickstart:cap21and40 --standalone --enable-core-artificially-accelerate-time-for-testing
+docker run --rm -it -p 8000:8000 --name stellar stellar/quickstart:cap21and40 --standalone
 ```
 
 The root account of the network will be:


### PR DESCRIPTION
### What
Remove the doc entry that demonstrates accelerating time of the Core network.

### Why
It's useful for development, but sort of adds more text to the docs that is unnecessary and makes it harder to understand and digest the getting started.