### PR TITLE
doc: add link to starlight implementation

### DIFF
--- a/specifications/starlight-payment-channel-mechanics.md
+++ b/specifications/starlight-payment-channel-mechanics.md
@@ -729,7 +729,8 @@ proposals.
 
 ## Implementations
 
-TODO: Add implementation.
+Prototype implementation of these mechanics in the `sdk/state` package of:
+https://github.com/stellar/starlight
 
 [CAP-21]: https://stellar.org/protocol/cap-21
 [CAP-33]: https://stellar.org/protocol/cap-33

--- a/specifications/starlight-payment-channel-mechanics.md
+++ b/specifications/starlight-payment-channel-mechanics.md
@@ -729,7 +729,7 @@ proposals.
 
 ## Implementations
 
-Prototype implementation of these mechanics in the `sdk/state` package of:
+Prototype implementation of these mechanics are in the `sdk/state` package of:
 https://github.com/stellar/starlight
 
 [CAP-21]: https://stellar.org/protocol/cap-21


### PR DESCRIPTION
### What
Add link to the prototype implementation in the specification.

### Why
We have a section there for it, may as well link to it.