### PR TITLE
sdk/agent/msg: add docs

### DIFF
--- a/sdk/agent/msg/msg.go
+++ b/sdk/agent/msg/msg.go
@@ -1,3 +1,8 @@
+// Package msg contains simple types to assist with transmitting and
+// communicating across a network about a payment channel between two
+// participants. It is rather rudimentary and intended for use in examples.
+// There are no stability or compatibility guarantees for the messages or
+// encoding format used.
 package msg
 
 import (
@@ -8,6 +13,8 @@ import (
 	"github.com/stellar/starlight/sdk/state"
 )
 
+// Type is the message type, used to indicate which message is contained inside
+// a Message.
 type Type int
 
 const (
@@ -20,6 +27,9 @@ const (
 	TypeCloseResponse   Type = 41
 )
 
+// Message is a message that can be transmitted to support two participants in a
+// payment channel communicating by signaling who they are with a hello, opening
+// the channel, making payments, and closing the channel.
 type Message struct {
 	Type Type
 
@@ -35,11 +45,16 @@ type Message struct {
 	CloseResponse *state.CloseSignatures
 }
 
+// Hello can be used to signal to another participant a minimal amount of
+// information the other participant needs to know about them.
 type Hello struct {
 	EscrowAccount keypair.FromAddress
 	Signer        keypair.FromAddress
 }
 
+// Encoder is an encoder that can be used to encode messages.
+// It is currently set as the encoding/gob.Encoder, but may be changed to
+// another type at anytime to facilitate testing or to improve performance.
 type Encoder = gob.Encoder
 
 func NewEncoder(w io.Writer) *Encoder {


### PR DESCRIPTION
### What
Add some docs to the sdk/agent/msg package.

### Why
To communicate the intent of the package, and the compatibility guarantees, or lack of, within.