### PR TITLE
sdk/agent/horizon: add docs

### DIFF
--- a/sdk/agent/horizon/balance_collector.go
+++ b/sdk/agent/horizon/balance_collector.go
@@ -7,13 +7,20 @@ import (
 	"github.com/stellar/go/clients/horizonclient"
 	"github.com/stellar/go/keypair"
 	"github.com/stellar/go/protocols/horizon"
+	"github.com/stellar/starlight/sdk/agent"
 	"github.com/stellar/starlight/sdk/state"
 )
 
+var _ agent.BalanceCollector = &BalanceCollector{}
+
+// BalanceCollector implements an agent's interface for collecting balances by
+// querying Horizon's accounts endpoint for the balance.
 type BalanceCollector struct {
 	HorizonClient horizonclient.ClientInterface
 }
 
+// GetBalance queries Horizon for the balance of the given asset on the given
+// account.
 func (h *BalanceCollector) GetBalance(accountID *keypair.FromAddress, asset state.Asset) (int64, error) {
 	var account horizon.Account
 	account, err := h.HorizonClient.AccountDetail(horizonclient.AccountRequest{AccountID: accountID.Address()})

--- a/sdk/agent/horizon/doc.go
+++ b/sdk/agent/horizon/doc.go
@@ -1,0 +1,4 @@
+// Package horizon contains types that implement a variety of interfaces defined
+// by the sdk/agent and its sub-packages, providing the functionality of those
+// interfaces by querying Horizon.
+package horizon

--- a/sdk/agent/horizon/sequence_number_collector.go
+++ b/sdk/agent/horizon/sequence_number_collector.go
@@ -5,12 +5,18 @@ import (
 
 	"github.com/stellar/go/clients/horizonclient"
 	"github.com/stellar/go/keypair"
+	"github.com/stellar/starlight/sdk/agent"
 )
 
+var _ agent.SequenceNumberCollector = &SequenceNumberCollector{}
+
+// SequenceNumberCollector implements an agent's interface for collecting the
+// current sequence number by querying Horizon's accounts endpoint.
 type SequenceNumberCollector struct {
 	HorizonClient horizonclient.ClientInterface
 }
 
+// GetSequenceNumber queries Horizon for the balance of the given account.
 func (h *SequenceNumberCollector) GetSequenceNumber(accountID *keypair.FromAddress) (int64, error) {
 	account, err := h.HorizonClient.AccountDetail(horizonclient.AccountRequest{AccountID: accountID.Address()})
 	if err != nil {

--- a/sdk/agent/horizon/streamer.go
+++ b/sdk/agent/horizon/streamer.go
@@ -11,6 +11,11 @@ import (
 	"github.com/stellar/starlight/sdk/agent"
 )
 
+var _ agent.Streamer = &Streamer{}
+
+// Streamer implements the agent's interface for streaming transactions that
+// affect a set of accounts, by using the streaming endpoints of Horizon's API
+// to collect new transactions as they occur.
 type Streamer struct {
 	HorizonClient horizonclient.ClientInterface
 	ErrorHandler  func(error)

--- a/sdk/agent/horizon/submitter.go
+++ b/sdk/agent/horizon/submitter.go
@@ -4,12 +4,18 @@ import (
 	"fmt"
 
 	"github.com/stellar/go/clients/horizonclient"
+	"github.com/stellar/starlight/sdk/agent/submit"
 )
 
+var _ submit.SubmitTxer = &Submitter{}
+
+// Submitter implements an submit's interface for submitting transaction XDRs to
+// the network, via Horizon's API.
 type Submitter struct {
 	HorizonClient horizonclient.ClientInterface
 }
 
+// SubmitTx submits the given xdr as a transaction to Horizon.
 func (h *Submitter) SubmitTx(xdr string) error {
 	_, err := h.HorizonClient.SubmitTransactionXDR(xdr)
 	if err != nil {

--- a/sdk/agent/submit/submitter.go
+++ b/sdk/agent/submit/submitter.go
@@ -8,6 +8,11 @@ import (
 	"github.com/stellar/go/txnbuild"
 )
 
+// SubmitTxer is an implementation of submitting transaction XDR to the network.
+type SubmitTxer interface {
+	SubmitTx(xdr string) error
+}
+
 // Submitter submits transactions to the network via Horizon. If a transaction
 // has a base fee below the submitters base fee, the transaction is wrapped in a
 // fee bump transaction. This means fee-less transactions are wrapped in fee
@@ -16,7 +21,7 @@ import (
 // The BaseFee is the base fee that will be used for any submission where the
 // transaction has a lower base fee.
 type Submitter struct {
-	SubmitTxer        interface{ SubmitTx(xdr string) error }
+	SubmitTxer        SubmitTxer
 	NetworkPassphrase string
 	BaseFee           int64
 	FeeAccount        *keypair.FromAddress


### PR DESCRIPTION
### What
Add some docs to the sdk/agent/horizon package.

### Why
To communicate the intent of the package.