### PR TITLE
sdk/agent: add docs

### DIFF
--- a/sdk/agent/agent.go
+++ b/sdk/agent/agent.go
@@ -83,7 +83,7 @@ type Config struct {
 	Events chan<- interface{}
 }
 
-// NewAgent constructs a new buffered agent with the given config.
+// NewAgent constructs a new agent with the given config.
 func NewAgent(c Config) *Agent {
 	agent := &Agent{
 		observationPeriodTime:      c.ObservationPeriodTime,

--- a/sdk/agent/agent.go
+++ b/sdk/agent/agent.go
@@ -61,6 +61,8 @@ type Snapshotter interface {
 	Snapshot(a *Agent, s Snapshot)
 }
 
+// Config contains the information that can be supplied to configure the Agent
+// at construction.
 type Config struct {
 	ObservationPeriodTime      time.Duration
 	ObservationPeriodLedgerGap int64
@@ -81,6 +83,7 @@ type Config struct {
 	Events chan<- interface{}
 }
 
+// NewAgent constructs a new buffered agent with the given config.
 func NewAgent(c Config) *Agent {
 	agent := &Agent{
 		observationPeriodTime:      c.ObservationPeriodTime,

--- a/sdk/agent/tcp.go
+++ b/sdk/agent/tcp.go
@@ -5,6 +5,8 @@ import (
 	"net"
 )
 
+// ServeTCP listens on the given address for a single incoming connection to
+// start a payment channel.
 func (a *Agent) ServeTCP(addr string) error {
 	if a.conn != nil {
 		return fmt.Errorf("already connected")
@@ -27,6 +29,8 @@ func (a *Agent) ServeTCP(addr string) error {
 	return nil
 }
 
+// ConnectTCP connects to the given address for establishing a single payment
+// channel.
 func (a *Agent) ConnectTCP(addr string) error {
 	if a.conn != nil {
 		return fmt.Errorf("already connected")


### PR DESCRIPTION
### What
Add some docs to the sdk/agentpackage.

### Why
Most types and functions were documented, but some were missing, and this fills the gaps.