### PR TITLE
examples/console: support friendbot for deployed environments

### DIFF
--- a/examples/console/main.go
+++ b/examples/console/main.go
@@ -201,10 +201,8 @@ func run() error {
 				if err != nil {
 					return err
 				}
-			} else {
-				if err != nil {
-					return err
-				}
+			} else if err != nil {
+				return err
 			}
 			account, err = horizonClient.AccountDetail(horizonclient.AccountRequest{AccountID: accountKey.Address()})
 		}

--- a/examples/console/main.go
+++ b/examples/console/main.go
@@ -198,10 +198,8 @@ func run() error {
 				fmt.Fprintf(os.Stdout, "friendbot not supported on this network\n")
 				fmt.Fprintf(os.Stdout, "attempting to create using network root key\n")
 				err = createAccountWithRoot(horizonClient, networkDetails.NetworkPassphrase, accountKey)
-				if err != nil {
-					return err
-				}
-			} else if err != nil {
+			}
+			if err != nil {
 				return err
 			}
 			account, err = horizonClient.AccountDetail(horizonclient.AccountRequest{AccountID: accountKey.Address()})

--- a/examples/console/main.go
+++ b/examples/console/main.go
@@ -191,10 +191,20 @@ func run() error {
 	if file == nil {
 		account, err := horizonClient.AccountDetail(horizonclient.AccountRequest{AccountID: accountKey.Address()})
 		if horizonclient.IsNotFoundError(err) {
-			fmt.Fprintf(os.Stdout, "account %s does not exist, attempting to create using network root key\n", accountKey.Address())
-			err = createAccountWithRoot(horizonClient, networkDetails.NetworkPassphrase, accountKey)
-			if err != nil {
-				return err
+			fmt.Fprintf(os.Stdout, "account %s does not exist\n", accountKey.Address())
+			fmt.Fprintf(os.Stdout, "attempting to create using friendbot\n")
+			_, err = horizonClient.Fund(accountKey.Address())
+			if horizonclient.IsNotFoundError(err) {
+				fmt.Fprintf(os.Stdout, "friendbot not supported on this network\n")
+				fmt.Fprintf(os.Stdout, "attempting to create using network root key\n")
+				err = createAccountWithRoot(horizonClient, networkDetails.NetworkPassphrase, accountKey)
+				if err != nil {
+					return err
+				}
+			} else {
+				if err != nil {
+					return err
+				}
 			}
 			account, err = horizonClient.AccountDetail(horizonclient.AccountRequest{AccountID: accountKey.Address()})
 		}


### PR DESCRIPTION
### What
Add support for deployed environments with a friendbot for creating the accounts in the console application.

### Why
To make the console application compatible with deployed environments where there is a friendbot for creating new test accounts.