### PR TITLE
sdk/state: unexport Channel.NextIterationNumber

### DIFF
--- a/sdk/state/integrationtests/state_test.go
+++ b/sdk/state/integrationtests/state_test.go
@@ -160,8 +160,6 @@ func TestOpenUpdatesUncoordinatedClose(t *testing.T) {
 	endingIterationNumber := int64(20)
 	for i < endingIterationNumber {
 		i++
-		require.Equal(t, i, initiatorChannel.NextIterationNumber())
-		require.Equal(t, i, responderChannel.NextIterationNumber())
 		// get a random payment amount from 0 to 100 lumens
 		amount := randomPositiveInt64(t, 100_0000000)
 
@@ -182,7 +180,6 @@ func TestOpenUpdatesUncoordinatedClose(t *testing.T) {
 			iBalanceCheck += amount
 		}
 		t.Log("Current channel balances: I: ", sendingChannel.Balance()/1_000_0000, "R: ", receivingChannel.Balance()/1_000_0000)
-		t.Log("Current channel iteration numbers: I: ", sendingChannel.NextIterationNumber(), "R: ", receivingChannel.NextIterationNumber())
 		t.Log("Proposal: ", i, paymentLog, amount/1_000_0000)
 
 		// Sender: creates new Payment, signs, sends to other party
@@ -428,8 +425,6 @@ func TestOpenUpdatesCoordinatedCloseStartCloseThenCoordinate(t *testing.T) {
 	endingIterationNumber := int64(20)
 	for i < endingIterationNumber {
 		i++
-		require.Equal(t, i, initiatorChannel.NextIterationNumber())
-		require.Equal(t, i, responderChannel.NextIterationNumber())
 		// get a random payment amount from 0 to 100 lumens
 		amount := randomPositiveInt64(t, 100_0000000)
 
@@ -449,7 +444,6 @@ func TestOpenUpdatesCoordinatedCloseStartCloseThenCoordinate(t *testing.T) {
 			iBalanceCheck += amount
 		}
 		t.Log("Current channel balances: I: ", sendingChannel.Balance()/1_000_0000, "R: ", receivingChannel.Balance()/1_000_0000)
-		t.Log("Current channel iteration numbers: I: ", sendingChannel.NextIterationNumber(), "R: ", receivingChannel.NextIterationNumber())
 		t.Log("Proposal: ", i, paymentLog, amount/1_000_0000)
 
 		// Sender: creates new Payment, signs, sends to other party
@@ -645,8 +639,6 @@ func TestOpenUpdatesCoordinatedCloseCoordinateThenStartClose(t *testing.T) {
 	endingIterationNumber := int64(20)
 	for i < endingIterationNumber {
 		i++
-		require.Equal(t, i, initiatorChannel.NextIterationNumber())
-		require.Equal(t, i, responderChannel.NextIterationNumber())
 		// get a random payment amount from 0 to 100 lumens
 		amount := randomPositiveInt64(t, 100_0000000)
 
@@ -666,7 +658,6 @@ func TestOpenUpdatesCoordinatedCloseCoordinateThenStartClose(t *testing.T) {
 			iBalanceCheck += amount
 		}
 		t.Log("Current channel balances: I: ", sendingChannel.Balance()/1_000_0000, "R: ", receivingChannel.Balance()/1_000_0000)
-		t.Log("Current channel iteration numbers: I: ", sendingChannel.NextIterationNumber(), "R: ", receivingChannel.NextIterationNumber())
 		t.Log("Proposal: ", i, paymentLog, amount/1_000_0000)
 
 		// Sender: creates new Payment, signs, sends to other party
@@ -862,8 +853,6 @@ func TestOpenUpdatesCoordinatedCloseCoordinateThenStartCloseByRemote(t *testing.
 	endingIterationNumber := int64(20)
 	for i < endingIterationNumber {
 		i++
-		require.Equal(t, i, initiatorChannel.NextIterationNumber())
-		require.Equal(t, i, responderChannel.NextIterationNumber())
 		// get a random payment amount from 0 to 100 lumens
 		amount := randomPositiveInt64(t, 100_0000000)
 
@@ -883,7 +872,6 @@ func TestOpenUpdatesCoordinatedCloseCoordinateThenStartCloseByRemote(t *testing.
 			iBalanceCheck += amount
 		}
 		t.Log("Current channel balances: I: ", sendingChannel.Balance()/1_000_0000, "R: ", receivingChannel.Balance()/1_000_0000)
-		t.Log("Current channel iteration numbers: I: ", sendingChannel.NextIterationNumber(), "R: ", receivingChannel.NextIterationNumber())
 		t.Log("Proposal: ", i, paymentLog, amount/1_000_0000)
 
 		// Sender: creates new Payment, signs, sends to other party

--- a/sdk/state/payment.go
+++ b/sdk/state/payment.go
@@ -207,7 +207,7 @@ func (c *Channel) ProposePaymentWithMemo(amount int64, memo []byte) (CloseAgreem
 	d := CloseDetails{
 		ObservationPeriodTime:      c.latestAuthorizedCloseAgreement.Envelope.Details.ObservationPeriodTime,
 		ObservationPeriodLedgerGap: c.latestAuthorizedCloseAgreement.Envelope.Details.ObservationPeriodLedgerGap,
-		IterationNumber:            c.NextIterationNumber(),
+		IterationNumber:            c.nextIterationNumber(),
 		Balance:                    newBalance,
 		ProposingSigner:            c.localSigner.FromAddress(),
 		ConfirmingSigner:           c.remoteSigner,
@@ -259,8 +259,8 @@ func (c *Channel) validatePayment(ce CloseEnvelope) (err error) {
 	}
 
 	// If the new close agreement details are incorrect, error.
-	if ce.Details.IterationNumber != c.NextIterationNumber() {
-		return fmt.Errorf("invalid payment iteration number, got: %d want: %d", ce.Details.IterationNumber, c.NextIterationNumber())
+	if ce.Details.IterationNumber != c.nextIterationNumber() {
+		return fmt.Errorf("invalid payment iteration number, got: %d want: %d", ce.Details.IterationNumber, c.nextIterationNumber())
 	}
 	if ce.Details.ObservationPeriodTime != c.latestAuthorizedCloseAgreement.Envelope.Details.ObservationPeriodTime ||
 		ce.Details.ObservationPeriodLedgerGap != c.latestAuthorizedCloseAgreement.Envelope.Details.ObservationPeriodLedgerGap {

--- a/sdk/state/state.go
+++ b/sdk/state/state.go
@@ -187,7 +187,7 @@ func (c *Channel) IsInitiator() bool {
 	return c.initiator
 }
 
-func (c *Channel) NextIterationNumber() int64 {
+func (c *Channel) nextIterationNumber() int64 {
 	if !c.latestUnauthorizedCloseAgreement.Envelope.Empty() {
 		return c.latestUnauthorizedCloseAgreement.Envelope.Details.IterationNumber
 	}


### PR DESCRIPTION
### What
Unexport the NextIterationNumber method of the Channel type.

### Why
It's dubious why a consumer of the package would need this function. If anything it exposes a little too much about the internals of the package. It may actually be difficult to use the function correctly or to fully understand why it returned the number it returned. In some cases it returns the current iteration, other times the next, depending on state and what is happening. This is because it always returns the iteration number of the next authorized transaction but that is counter intuitive when a participant has proposed a new payment because that payment is unauthorized. Unexporting the function removes this complexity from the packages surface API.

The only place it is used outside the package is in the integration tests, and there only for logging. The logging may be useful, but I don't think it is critical.