### PR TITLE
Update docs to reference docker image on docker.io

### DIFF
--- a/Getting Started.md
+++ b/Getting Started.md
@@ -34,11 +34,7 @@ To run a standalone network use the branch of the `stellar/quickstart` docker im
 ### Locally
 
 ```
-docker build -t stellar/quickstart:cap21and40 git://github.com/stellar/docker-stellar-core-horizon#cap21and40
-```
-
-```
-docker run --rm -it -p 8000:8000 --name stellar stellar/quickstart:cap21and40 --standalone
+docker run --rm -it -p 8000:8000 --name stellar stellar/quickstart:pr-294 --standalone
 ```
 
 The root account of the network will be:


### PR DESCRIPTION
### What
Update the getting started docs to reference the docker image published to docker.io.

### Why
The getting started docs show how to build the image, but building the image is unnecessary as it is now published to docker.io.