### PR TITLE
docs: update instructions for running

### DIFF
--- a/.github/workflows/sdk.yml
+++ b/.github/workflows/sdk.yml
@@ -57,7 +57,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
     - name: "Stellar Quickstart w/ Protocol 19: Run"
-      run: docker run -d -p 8000:8000 --name stellar stellar/quickstart:pr-341-dev --standalone --enable-core-artificially-accelerate-time-for-testing
+      run: docker run -d -p 8000:8000 --name stellar stellar/quickstart:testing --standalone --enable-core-artificially-accelerate-time-for-testing
     - name: "Stellar Quickstart w/ Protocol 19: Wait for Ready"
       run: while ! [ "$(curl -s --fail localhost:8000 | jq '.history_latest_ledger')" -gt 0 ]; do echo waiting; sleep 1; done
     - name: "Stellar Quickstart w/ Protocol 19: Details"

--- a/Getting Started.md
+++ b/Getting Started.md
@@ -1,31 +1,9 @@
 # Getting Started
 
-- [Connecting to the deployed devnet](#connecting-to-the-deployed-devnet)
 - [Running your own devnet with CAP-21 and CAP-40](#running-your-own-devnet-with-cap-21-and-cap-40)
 - [Experiment with the prototype Starlight Go SDK](#experiment-with-the-prototype-starlight-go-sdk)
 - [Run the console example application](#run-the-console-example-application)
 - [Manually inspect or build transactions](#manually-inspect-or-build-transactions)
-
-## Connecting to the deployed devnet
-
-The deployed devnet is a development network with no uptime or data durability
-guarantees. It is intended for convenient use with examples or testing. A
-network reset occurs when deployed.
-
-Horizon: https://horizon-devnet-cap21and40.stellar.org  
-Network Passphrase: `Starlight Network; October 2021`
-
-To run the example console application with the deployed devnet:
-
-```
-git clone https://github.com/stellar/starlight
-cd examples/console
-go run . -horizon=http://horizon-devnet-cap21and40.stellar.org
->>> help
-```
-
-Run two copies of the example console application and connect them directly over
-TCP to open a payment channel between two participants.
 
 ## Running your own devnet with CAP-21 and CAP-40
 
@@ -34,7 +12,7 @@ To run a standalone network use the branch of the `stellar/quickstart` docker im
 ### Locally
 
 ```
-docker run --rm -it -p 8000:8000 --name stellar stellar/quickstart:pr-341-dev --standalone
+docker run --rm -it -p 8000:8000 --name stellar stellar/quickstart:testing --standalone
 ```
 
 Test that the network is running by curling the root endpoint:

--- a/README.md
+++ b/README.md
@@ -28,20 +28,18 @@ The Starlight protocol, SDK, code in this repository, and any forks of other Ste
 
 ## Try it out
 
-The devnet is a development network with partial implementations of CAP-21 and
-CAP-40, required for the Starlight protocol. It is intended for convenient use
-with examples or testing. It has no uptime or data durability guarantees and a
-network reset occurs when deployed.
+Run a devnet locally which runs stellar-core, horizon and friendbot:
 
-Horizon: https://horizon-devnet-cap21and40.stellar.org  
-Network Passphrase: `Starlight Network; October 2021`
+```
+docker run --rm -it -p 8000:8000 --name stellar stellar/quickstart:testing --standalone
+```
 
 To run the example console application with the deployed devnet:
 
 ```
 git clone https://github.com/stellar/starlight
 cd examples/console
-go run . -horizon=http://horizon-devnet-cap21and40.stellar.org
+go run . -horizon=http://localhost:8000
 >>> help
 ```
 


### PR DESCRIPTION
### What
Update instructions for running the examples and docker image. Remove instructions for the devnet.

###
The instructions are out of date now that Horizon and Stellar-Core have released RCs. The devnet is out of date. It'll be updated in https://github.com/stellar/ops/issues/1674, but in the meantime remove the instructions.