### PR TITLE
examples/console: add log for when close occurs that is outdated

### DIFF
--- a/examples/console/main.go
+++ b/examples/console/main.go
@@ -163,6 +163,8 @@ func run() error {
 
 			case agentpkg.ClosingEvent:
 				fmt.Fprintf(os.Stderr, "channel closing\n")
+			case agentpkg.ClosingWithOutdatedStateEvent:
+				fmt.Fprintf(os.Stderr, "channel closing with outdated state\n")
 			case agentpkg.ClosedEvent:
 				fmt.Fprintf(os.Stderr, "channel closed\n")
 			}


### PR DESCRIPTION
### What
Add log for when close occurs that is outdated.

### Why
Helpful for debugging.