### PR TITLE
all: update test env to testnet

### DIFF
--- a/.github/workflows/sdk.yml
+++ b/.github/workflows/sdk.yml
@@ -56,11 +56,11 @@ jobs:
   integration-tests:
     runs-on: ubuntu-latest
     steps:
-    - name: "Stellar Quickstart w/ Protocol 19: Run"
-      run: docker run -d -p 8000:8000 --name stellar stellar/quickstart:testing --standalone --enable-core-artificially-accelerate-time-for-testing
-    - name: "Stellar Quickstart w/ Protocol 19: Wait for Ready"
+    - name: "Stellar Quickstart: Run"
+      run: docker run -d -p 8000:8000 --name stellar stellar/quickstart --standalone --enable-core-artificially-accelerate-time-for-testing
+    - name: "Stellar Quickstart: Wait for Ready"
       run: while ! [ "$(curl -s --fail localhost:8000 | jq '.history_latest_ledger')" -gt 0 ]; do echo waiting; sleep 1; done
-    - name: "Stellar Quickstart w/ Protocol 19: Details"
+    - name: "Stellar Quickstart: Details"
       run: curl localhost:8000
     - name: Checkout
       uses: actions/checkout@v2
@@ -73,3 +73,4 @@ jobs:
       run: go test -v -race -p=1 ./**/integrationtests
       env:
         INTEGRATION_TESTS: 1
+        INTEGRATION_TESTS_HORIZON_URL: http://localhost:8000

--- a/Getting Started.md
+++ b/Getting Started.md
@@ -1,9 +1,16 @@
 # Getting Started
 
+- [Testing with testnet](#testing-with-testnet)
 - [Running your own devnet with CAP-21 and CAP-40](#running-your-own-devnet-with-cap-21-and-cap-40)
 - [Experiment with the prototype Starlight Go SDK](#experiment-with-the-prototype-starlight-go-sdk)
 - [Run the console example application](#run-the-console-example-application)
 - [Manually inspect or build transactions](#manually-inspect-or-build-transactions)
+
+## Testing with testnet
+
+The Stellar testnet has protocol 19 implemented:
+
+https://horizon-testnet.stellar.org
 
 ## Running your own devnet with CAP-21 and CAP-40
 

--- a/README.md
+++ b/README.md
@@ -16,11 +16,10 @@ Starlight is a prototype layer 2 payment channel protocol for the Stellar Networ
 
 This repository contains a experiments, prototypes, documents, and issues
 relating to implementing the Starlight protocol on the Stellar network.
-Protoypes here are dependent on Protocol 19 and Core Advancement Protocols, [CAP-21] and
-[CAP-40], that are not yet released. You can experiment with the
-Starlight protocol by using the devnet, or running a Stellar network in
-a docker container. To find out how, see [Getting
-Started](Getting%20Started.md).
+Protoypes here are dependent on Protocol 19 and Core Advancement Protocols,
+[CAP-21] and [CAP-40]. You can experiment with the Starlight protocol by using
+the testnet, or running a Stellar network in a docker container. To find out
+how, see [Getting Started](Getting%20Started.md).
 
 ![Diagram of two people opening a payment channel, transacting off-network, and closing the payment channel.](README-diagram.png)
 
@@ -28,18 +27,12 @@ The Starlight protocol, SDK, code in this repository, and any forks of other Ste
 
 ## Try it out
 
-Run a devnet locally which runs stellar-core, horizon and friendbot:
-
-```
-docker run --rm -it -p 8000:8000 --name stellar stellar/quickstart:testing --standalone
-```
-
-To run the example console application with the deployed devnet:
+Run the example console application with testnet:
 
 ```
 git clone https://github.com/stellar/starlight
 cd examples/console
-go run . -horizon=http://localhost:8000
+go run .
 >>> help
 ```
 
@@ -65,14 +58,10 @@ More details in the [README](https://github.com/stellar/starlight/tree/main/exam
 
 - Live chat is on the `#starlight` channel in [Discord](https://discord.gg/xGWRjyNzQh)
 - Discussions about Starlight are on [GitHub Discussions](https://github.com/stellar/starlight/discussions)
-- Discussions about CAP-21 and CAP-40:
-  - CAP-21 thread on the [stellar-dev mailing list](https://groups.google.com/g/stellar-dev/c/Wp7gNaJvt40)
-  - CAP-40 thread on the [stellar-dev mailing list](https://groups.google.com/g/stellar-dev/c/Wp7gNaJvt40)
-  - Live Protocol Meetings: https://www.youtube.com/playlist?list=PLmr3tp_7-7Gj9cTR5ieSaRHxiA2zItFyx
 
 ## Protocol 19
 
-The code in this repository is dependent on changes to the Stellar protocol coming in Protocol 19, specifically the changes described by [CAP-21] and [CAP-40]. Protocol 19 is in development.
+The code in this repository is dependent on changes to the Stellar protocol coming in Protocol 19, specifically the changes described by [CAP-21] and [CAP-40]. Protocol 19 is released.
 
 [CAP-21]: https://stellar.org/protocol/cap-21
 [CAP-40]: https://stellar.org/protocol/cap-40

--- a/examples/console/README.md
+++ b/examples/console/README.md
@@ -10,15 +10,12 @@ This example is a rough example and is brittle and is still a work in progress.
 
 ## Usage
 
-Follow the [Getting Started](../../Getting%20Started.md) instructions to run a
-stellar-core and horizon with CAP-21 and CAP-40 capabilities.
-
 Run the example using the below commands.
 
 ```
 git clone https://github.com/stellar/starlight
 cd examples/console
-go run . -horizon=http://localhost:8000
+go run .
 ```
 
 Type `help` once in to discover commands to use.
@@ -31,7 +28,7 @@ tty device.
 
 Run these commands on the first terminal:
 ```
-$ go run . -horizon=http://localhost:8000
+$ go run .
 > listen :6000
 > open
 > deposit 100
@@ -41,7 +38,7 @@ $ go run . -horizon=http://localhost:8000
 
 Run these commands in the second terminal:
 ```
-$ go run . -horizon=http://localhost:8000
+$ go run .
 > connect :6000
 > deposit 80
 > pay 2

--- a/examples/console/main.go
+++ b/examples/console/main.go
@@ -48,7 +48,7 @@ var (
 
 func run() error {
 	showHelp := false
-	horizonURL := "http://localhost:8000"
+	horizonURL := "http://horizon-testnet.stellar.org"
 	signerKeyStr := "S..."
 	filename := ""
 	httpPort := ""

--- a/examples/dashboard.html
+++ b/examples/dashboard.html
@@ -71,7 +71,7 @@
   params.remoteName ||= "Remote";
 
   window.addEventListener('load', (event) => {
-    const horizonUrl = "http://192.168.64.2:8000";
+    const horizonUrl = "http://horizon-testnet.stellar.org";
     const agentUrl = "http://localhost:9000";
 
     const updateCharts = async (chartUpdateFuncs) => {

--- a/sdk/state/integrationtests/main_test.go
+++ b/sdk/state/integrationtests/main_test.go
@@ -13,7 +13,7 @@ import (
 var horizonURL = func() string {
 	url := os.Getenv("INTEGRATION_TESTS_HORIZON_URL")
 	if url == "" {
-		url = "http://localhost:8000"
+		url = "http://horizon-testnet.stellar.org"
 	}
 	return url
 }()


### PR DESCRIPTION
### What
Update the docs and integration tests to run against testnet by default, but still run the CI integration tests against quickstart.

### Why
It's all on testnet now.